### PR TITLE
feat: add unix support

### DIFF
--- a/backend/fileops.go
+++ b/backend/fileops.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package backend
 
 import (

--- a/backend/fileops_unix.go
+++ b/backend/fileops_unix.go
@@ -1,0 +1,246 @@
+//go:build !windows
+
+package backend
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// NewFileOperationsManager creates a new file operations manager instance
+func NewFileOperationsManager(platform PlatformManagerInterface) *FileOperationsManager {
+	return &FileOperationsManager{platform: platform}
+}
+
+// CopyFiles copies files from source paths to destination directory with rollback support
+func (fo *FileOperationsManager) CopyFiles(sourcePaths []string, destDir string) bool {
+	log.Printf("Copying %d files to: %s", len(sourcePaths), destDir)
+
+	if len(sourcePaths) == 0 {
+		log.Printf("Error: No source paths provided")
+		return false
+	}
+	if destDir == "" {
+		log.Printf("Error: Destination directory cannot be empty")
+		return false
+	}
+
+	destInfo, err := os.Stat(destDir)
+	if err != nil {
+		log.Printf("Error: Cannot access destination directory: %v", err)
+		return false
+	}
+	if !destInfo.IsDir() {
+		log.Printf("Error: Destination is not a directory: %s", destDir)
+		return false
+	}
+
+	var copiedFiles []string
+	defer func() {
+		if len(copiedFiles) > 0 && len(copiedFiles) < len(sourcePaths) {
+			log.Printf("Cleaning up %d partially copied files", len(copiedFiles))
+			for _, f := range copiedFiles {
+				os.RemoveAll(f)
+			}
+		}
+	}()
+
+	for _, srcPath := range sourcePaths {
+		if srcPath == "" {
+			log.Printf("Error: Empty source path found")
+			return false
+		}
+		if _, err := os.Stat(srcPath); err != nil {
+			log.Printf("Error: Cannot access source file %s: %v", srcPath, err)
+			return false
+		}
+		destPath := filepath.Join(destDir, filepath.Base(srcPath))
+		if _, err := os.Stat(destPath); err == nil {
+			log.Printf("Error: Destination file already exists: %s", destPath)
+			return false
+		}
+	}
+
+	return fo.copyFilesStandardWithRollback(sourcePaths, destDir, &copiedFiles)
+}
+
+// MoveFiles moves files from source paths to destination directory with rollback
+func (fo *FileOperationsManager) MoveFiles(sourcePaths []string, destDir string) bool {
+	log.Printf("Moving %d files to: %s", len(sourcePaths), destDir)
+
+	if len(sourcePaths) == 0 {
+		log.Printf("Error: No source paths provided")
+		return false
+	}
+	if destDir == "" {
+		log.Printf("Error: Destination directory cannot be empty")
+		return false
+	}
+
+	destInfo, err := os.Stat(destDir)
+	if err != nil {
+		log.Printf("Error: Cannot access destination directory: %v", err)
+		return false
+	}
+	if !destInfo.IsDir() {
+		log.Printf("Error: Destination is not a directory: %s", destDir)
+		return false
+	}
+
+	type moveRecord struct {
+		srcPath string
+		dstPath string
+	}
+	var moves []moveRecord
+	rollback := func() {
+		for i := len(moves) - 1; i >= 0; i-- {
+			os.Rename(moves[i].dstPath, moves[i].srcPath)
+		}
+	}
+
+	for _, srcPath := range sourcePaths {
+		destPath := filepath.Join(destDir, filepath.Base(srcPath))
+		if err := os.Rename(srcPath, destPath); err != nil {
+			if err := fo.copyDirOrFile(srcPath, destPath); err != nil {
+				log.Printf("Error moving %s: %v", srcPath, err)
+				rollback()
+				return false
+			}
+			if err := os.RemoveAll(srcPath); err != nil {
+				log.Printf("Error removing original %s: %v", srcPath, err)
+				rollback()
+				return false
+			}
+		}
+		moves = append(moves, moveRecord{srcPath: srcPath, dstPath: destPath})
+	}
+
+	return true
+}
+
+// helper to copy file or directory
+func (fo *FileOperationsManager) copyDirOrFile(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fo.copyDir(src, dst)
+	}
+	return fo.copyFile(src, dst)
+}
+
+// DeleteFiles permanently deletes the specified files and directories
+func (fo *FileOperationsManager) DeleteFiles(filePaths []string) bool {
+	log.Printf("Permanently deleting %d files", len(filePaths))
+	for _, filePath := range filePaths {
+		if err := os.RemoveAll(filePath); err != nil {
+			log.Printf("Error permanently deleting %s: %v", filePath, err)
+			return false
+		}
+	}
+	return true
+}
+
+// MoveFilesToRecycleBin moves files to the system recycle bin/trash using platform tools
+func (fo *FileOperationsManager) MoveFilesToRecycleBin(filePaths []string) bool {
+	log.Printf("Moving %d files to recycle bin", len(filePaths))
+	for _, filePath := range filePaths {
+		if !fo.moveToRecycleBin(filePath) {
+			log.Printf("Error moving %s to recycle bin", filePath)
+			return false
+		}
+	}
+	return true
+}
+
+// RenameFile renames a file or directory with validation
+func (fo *FileOperationsManager) RenameFile(oldPath, newName string) bool {
+	log.Printf("Renaming %s to %s", oldPath, newName)
+
+	if oldPath == "" || newName == "" {
+		log.Printf("Error: paths cannot be empty")
+		return false
+	}
+
+	cleanOldPath := filepath.Clean(oldPath)
+	if !filepath.IsAbs(cleanOldPath) {
+		log.Printf("Error: Old path must be absolute: %s", oldPath)
+		return false
+	}
+
+	tempFS := &FileSystemManager{}
+	sanitizedNewName, err := tempFS.validateAndSanitizeFileName(newName)
+	if err != nil {
+		log.Printf("Error: Invalid new name: %v", err)
+		return false
+	}
+
+	dir := filepath.Dir(cleanOldPath)
+	newPath := filepath.Join(dir, sanitizedNewName)
+
+	if _, err := os.Stat(cleanOldPath); os.IsNotExist(err) {
+		log.Printf("Error: Source file does not exist: %s", cleanOldPath)
+		return false
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		log.Printf("Error: Destination already exists: %s", newPath)
+		return false
+	}
+
+	if err := os.Rename(cleanOldPath, newPath); err != nil {
+		log.Printf("Error renaming file: %v", err)
+		return false
+	}
+	return true
+}
+
+// HideFiles sets the hidden attribute on the specified files
+func (fo *FileOperationsManager) HideFiles(filePaths []string) bool {
+	log.Printf("Hiding %d files", len(filePaths))
+	for _, filePath := range filePaths {
+		if !fo.platform.HideFile(filePath) {
+			log.Printf("Error hiding file: %s", filePath)
+			return false
+		}
+	}
+	return true
+}
+
+// OpenFile opens a file with its default application
+func (fo *FileOperationsManager) OpenFile(filePath string) bool {
+	return fo.platform.OpenFile(filePath)
+}
+
+// copyFilesStandardWithRollback uses Go standard library for file copying with rollback support
+func (fo *FileOperationsManager) copyFilesStandardWithRollback(sourcePaths []string, destDir string, copiedFiles *[]string) bool {
+	for _, srcPath := range sourcePaths {
+		srcInfo, err := os.Stat(srcPath)
+		if err != nil {
+			log.Printf("Error getting source file info: %v", err)
+			return false
+		}
+
+		destPath := filepath.Join(destDir, filepath.Base(srcPath))
+
+		var copyErr error
+		if srcInfo.IsDir() {
+			copyErr = fo.copyDir(srcPath, destPath)
+		} else {
+			copyErr = fo.copyFile(srcPath, destPath)
+		}
+		if copyErr != nil {
+			log.Printf("Error copying %s: %v", srcPath, copyErr)
+			return false
+		}
+		*copiedFiles = append(*copiedFiles, destPath)
+		if _, err := os.Stat(destPath); err != nil {
+			log.Printf("Copy verification failed for %s: %v", destPath, err)
+			return false
+		}
+	}
+
+	*copiedFiles = nil
+	return true
+}

--- a/backend/filesystem_stream.go
+++ b/backend/filesystem_stream.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package backend
 
 import (

--- a/backend/filesystem_stream_unix.go
+++ b/backend/filesystem_stream_unix.go
@@ -1,0 +1,91 @@
+//go:build !windows
+
+package backend
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// BasicEntry holds minimal info for instant UI rendering
+type BasicEntry struct {
+	Name      string `json:"name"`
+	Path      string `json:"path"`
+	IsDir     bool   `json:"isDir"`
+	Extension string `json:"extension"`
+	IsHidden  bool   `json:"isHidden"`
+}
+
+// EnhancedBasicEntry holds complete file information
+type EnhancedBasicEntry struct {
+	BasicEntry
+	Size        int64  `json:"size"`
+	ModTime     int64  `json:"modTime"`
+	Permissions string `json:"permissions"`
+}
+
+var (
+	extensionCache   = make(map[string]string)
+	extensionCacheMu sync.RWMutex
+)
+
+func getExtensionCached(name string) string {
+	extensionCacheMu.RLock()
+	if ext, ok := extensionCache[name]; ok {
+		extensionCacheMu.RUnlock()
+		return ext
+	}
+	extensionCacheMu.RUnlock()
+
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(name), "."))
+
+	extensionCacheMu.Lock()
+	if _, ok := extensionCache[name]; !ok {
+		if len(extensionCache) < 10000 {
+			extensionCache[name] = ext
+		}
+	}
+	extensionCacheMu.Unlock()
+
+	return ext
+}
+
+// listDirectoryBasicEnhanced uses standard library to enumerate directory entries
+func listDirectoryBasicEnhanced(dir string) ([]EnhancedBasicEntry, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]EnhancedBasicEntry, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		fullPath := filepath.Join(dir, name)
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		isDir := entry.IsDir()
+		isHidden := strings.HasPrefix(name, ".")
+		ext := ""
+		if !isDir {
+			ext = getExtensionCached(name)
+		}
+		result = append(result, EnhancedBasicEntry{
+			BasicEntry: BasicEntry{
+				Name:      name,
+				Path:      fullPath,
+				IsDir:     isDir,
+				IsHidden:  isHidden,
+				Extension: ext,
+			},
+			Size:        info.Size(),
+			ModTime:     info.ModTime().Unix(),
+			Permissions: info.Mode().String(),
+		})
+	}
+
+	return result, nil
+}

--- a/backend/platform_unix.go
+++ b/backend/platform_unix.go
@@ -1,0 +1,119 @@
+//go:build !windows
+
+package backend
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// NewPlatformManager creates a new platform manager instance
+func NewPlatformManager() *PlatformManager {
+	return &PlatformManager{}
+}
+
+// GetHomeDirectory returns the user's home directory
+func (p *PlatformManager) GetHomeDirectory() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("Error getting home directory: %v", err)
+		return ""
+	}
+	return homeDir
+}
+
+// GetCurrentWorkingDirectory returns the current working directory
+func (p *PlatformManager) GetCurrentWorkingDirectory() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Printf("Error getting current working directory: %v", err)
+		return ""
+	}
+	return cwd
+}
+
+// GetSystemRoots returns system root paths for quick navigation
+func (p *PlatformManager) GetSystemRoots() []string {
+	// For Unix-like systems, the root is always '/'
+	return []string{"/"}
+}
+
+// OpenInSystemExplorer opens the given path in the system file explorer
+func (p *PlatformManager) OpenInSystemExplorer(path string) bool {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("open", path)
+	} else {
+		cmd = exec.Command("xdg-open", path)
+	}
+
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error opening path in system explorer: %v", err)
+		return false
+	}
+	return true
+}
+
+// OpenFile opens a file with its default application
+func (p *PlatformManager) OpenFile(filePath string) bool {
+	return p.OpenInSystemExplorer(filePath)
+}
+
+// IsHiddenWindows is not applicable on non-Windows platforms
+func (p *PlatformManager) IsHiddenWindows(filePath string) bool {
+	return false
+}
+
+// IsHidden checks if a file/directory is hidden using Unix conventions
+func (p *PlatformManager) IsHidden(filePath string) bool {
+	name := filepath.Base(filePath)
+	return strings.HasPrefix(name, ".")
+}
+
+// GetExtension returns the file extension in lowercase
+func (p *PlatformManager) GetExtension(name string) string {
+	return strings.TrimPrefix(strings.ToLower(filepath.Ext(name)), ".")
+}
+
+// HideFile renames the file to start with a dot to hide it
+func (p *PlatformManager) HideFile(filePath string) bool {
+	if p.IsHidden(filePath) {
+		return true
+	}
+
+	dir := filepath.Dir(filePath)
+	base := filepath.Base(filePath)
+	newPath := filepath.Join(dir, "."+base)
+	if err := os.Rename(filePath, newPath); err != nil {
+		log.Printf("Error hiding file %s: %v", filePath, err)
+		return false
+	}
+	return true
+}
+
+// FormatFileSize formats file size in human readable format
+func (p *PlatformManager) FormatFileSize(size int64) string {
+	const unit = 1024
+	if size < unit {
+		return fmt.Sprintf("%d B", size)
+	}
+
+	div, exp := int64(unit), 0
+	for n := size / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	units := []string{"KB", "MB", "GB", "TB", "PB"}
+	return fmt.Sprintf("%.1f %s", float64(size)/float64(div), units[exp])
+}
+
+// GetWindowsDrivesOptimized is a Windows-specific helper. On non-Windows platforms it returns nil.
+func (p *PlatformManager) GetWindowsDrivesOptimized() []DriveInfo {
+	return nil
+}

--- a/backend/terminal.go
+++ b/backend/terminal.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 package backend
 
 import (
@@ -13,8 +15,8 @@ import (
 )
 
 var (
-	shell32Terminal  = syscall.NewLazyDLL("shell32.dll")
-		ernel32Terminal = syscall.NewLazyDLL("kernel32.dll")
+	shell32Terminal = syscall.NewLazyDLL("shell32.dll")
+	ernel32Terminal = syscall.NewLazyDLL("kernel32.dll")
 
 	// Shell32 procedures for terminal operations
 	shellExecuteW = shell32Terminal.NewProc("ShellExecuteW")

--- a/backend/terminal_unix.go
+++ b/backend/terminal_unix.go
@@ -1,0 +1,187 @@
+//go:build !windows
+
+package backend
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// NewTerminalManager creates a new terminal manager instance
+func NewTerminalManager() *TerminalManager {
+	return &TerminalManager{}
+}
+
+// OpenPowerShellHere attempts to open PowerShell if available, otherwise falls back to default terminal
+func (t *TerminalManager) OpenPowerShellHere(directoryPath string) bool {
+	securePath, err := t.securePath(directoryPath)
+	if err != nil {
+		log.Printf("Error: %v", err)
+		return false
+	}
+
+	if _, err := exec.LookPath("pwsh"); err == nil {
+		cmd := exec.Command("pwsh", "-NoExit", "-c", "cd "+shellescape(securePath))
+		cmd.Dir = securePath
+		if err := cmd.Start(); err == nil {
+			return true
+		}
+	}
+
+	return t.OpenTerminalHere(securePath)
+}
+
+// OpenTerminalHere opens the system's default terminal in the specified directory
+func (t *TerminalManager) OpenTerminalHere(directoryPath string) bool {
+	securePath, err := t.securePath(directoryPath)
+	if err != nil {
+		log.Printf("Error: %v", err)
+		return false
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		return t.openMacTerminal(securePath)
+	case "linux":
+		return t.openLinuxTerminal(securePath)
+	default:
+		log.Printf("Unsupported operating system: %s", runtime.GOOS)
+		return false
+	}
+}
+
+// GetAvailableTerminals returns a list of available terminal applications
+func (t *TerminalManager) GetAvailableTerminals() []string {
+	var terminals []string
+	switch runtime.GOOS {
+	case "darwin":
+		terminals = append(terminals, "Terminal", "iTerm2")
+	case "linux":
+		candidates := []string{
+			"gnome-terminal", "konsole", "xfce4-terminal", "xterm", "urxvt", "terminator", "alacritty", "kitty",
+		}
+		for _, c := range candidates {
+			if _, err := exec.LookPath(c); err == nil {
+				terminals = append(terminals, c)
+			}
+		}
+	}
+	return terminals
+}
+
+// ExecuteCommand executes a command in the specified working directory
+func (t *TerminalManager) ExecuteCommand(command string, workingDir string) error {
+	log.Printf("Executing command: %s in directory: %s", command, workingDir)
+	if command == "" {
+		return fmt.Errorf("command cannot be empty")
+	}
+
+	var secureWorkingDir string
+	if workingDir != "" {
+		var err error
+		secureWorkingDir, err = t.securePath(workingDir)
+		if err != nil {
+			return fmt.Errorf("invalid working directory: %v", err)
+		}
+	}
+
+	dangerousPatterns := []string{
+		"rm -rf /", "shutdown", "reboot", "poweroff", "&& rm", "| rm", "; rm",
+	}
+	lower := strings.ToLower(command)
+	for _, p := range dangerousPatterns {
+		if strings.Contains(lower, p) {
+			return fmt.Errorf("command contains potentially dangerous pattern: %s", p)
+		}
+	}
+
+	cmd := exec.Command("sh", "-c", command)
+	if secureWorkingDir != "" {
+		cmd.Dir = secureWorkingDir
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Printf("Command execution failed: %v, output: %s", err, string(output))
+		return err
+	}
+	log.Printf("Command executed successfully, output: %s", string(output))
+	return nil
+}
+
+// securePath sanitizes a directory path to prevent command injection
+func (t *TerminalManager) securePath(directoryPath string) (string, error) {
+	if directoryPath == "" {
+		return "", fmt.Errorf("directory path cannot be empty")
+	}
+	cleanPath := filepath.Clean(directoryPath)
+	if !filepath.IsAbs(cleanPath) {
+		return "", fmt.Errorf("directory path must be absolute")
+	}
+	info, err := os.Stat(cleanPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("directory does not exist: %s", cleanPath)
+		}
+		return "", fmt.Errorf("cannot access directory: %v", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path is not a directory: %s", cleanPath)
+	}
+
+	dangerousChars := []string{";", "&", "|", "`", "$", "(", ")", "{", "}", "[", "]", "<", ">", "\"", "'", "\n", "\r", "\t"}
+	for _, ch := range dangerousChars {
+		if strings.Contains(cleanPath, ch) {
+			return "", fmt.Errorf("directory path contains potentially dangerous characters: %s", ch)
+		}
+	}
+	return cleanPath, nil
+}
+
+// openMacTerminal opens Terminal in macOS with secure path handling
+func (t *TerminalManager) openMacTerminal(directoryPath string) bool {
+	tempScript := fmt.Sprintf(`tell application "Terminal" to do script "cd %s"`, strings.ReplaceAll(directoryPath, "'", "'\"'\"'"))
+	cmd := exec.Command("osascript", "-e", tempScript)
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error opening macOS Terminal: %v", err)
+		return false
+	}
+	return true
+}
+
+// openLinuxTerminal opens terminal in Linux with secure execution
+func (t *TerminalManager) openLinuxTerminal(directoryPath string) bool {
+	terminals := []struct {
+		command string
+		args    []string
+	}{
+		{"gnome-terminal", []string{"--working-directory=" + directoryPath}},
+		{"konsole", []string{"--workdir", directoryPath}},
+		{"xfce4-terminal", []string{"--working-directory=" + directoryPath}},
+		{"terminator", []string{"--working-directory=" + directoryPath}},
+		{"xterm", []string{"-e", "bash", "-c", fmt.Sprintf("cd %s && exec bash", shellescape(directoryPath))}},
+		{"urxvt", []string{"-cd", directoryPath}},
+	}
+	for _, term := range terminals {
+		if _, err := exec.LookPath(term.command); err == nil {
+			cmd := exec.Command(term.command, term.args...)
+			cmd.Dir = directoryPath
+			if err := cmd.Start(); err == nil {
+				log.Printf("Successfully opened %s in directory: %s", term.command, directoryPath)
+				return true
+			}
+		}
+	}
+	log.Printf("No terminal emulator found")
+	return false
+}
+
+// shellescape properly escapes a string for shell use
+func shellescape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
+}


### PR DESCRIPTION
## Summary
- add non-Windows platform manager with standard OS operations
- implement Unix directory streaming, file operations, and terminal helpers
- gate existing Windows-specific code with build tags for cross-platform builds

## Testing
- `GOWORK=off go build ./backend...`
- `bun run lint` *(fails: Script not found "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68acd4c2bea4832eade2023567cc0a95